### PR TITLE
Add non-Pack variants for calculation methods

### DIFF
--- a/src/online/first_fit.rs
+++ b/src/online/first_fit.rs
@@ -1,4 +1,4 @@
-use crate::{Bin, Pack};
+use crate::{wrapper::SizedWrapper, Bin, Pack};
 
 /// Pack items in bins using the [First-fit](https://en.wikipedia.org/wiki/First-fit_bin_packing)
 /// bin packing algorithm.
@@ -9,6 +9,36 @@ where
     assert!(bin_size > 0, "Bin size must be greater than 0");
 
     __internal_first_fit(bin_size, items, 1)
+}
+
+/// Pack items in bins using the [First-fit](https://en.wikipedia.org/wiki/First-fit_bin_packing)
+/// bin packing algorithm.
+///
+/// Unlike [`first_fit`], the items don't have to implement [`Pack`].
+/// Instead, you need to provide a function that returns the size of the item.
+///
+/// This function will be cloned for each item
+/// (but if it's a simple function pointer or a non-capturing closure, then it is a no-op).
+pub fn first_fit_by_key<T, SizeFunc>(
+    bin_size: usize,
+    items: impl IntoIterator<Item = T>,
+    key_func: SizeFunc,
+) -> Vec<Bin<T>>
+where
+    SizeFunc: Fn(&T) -> usize + Clone,
+{
+    assert!(bin_size > 0, "Bin size must be greater than 0");
+
+    __internal_first_fit(
+        bin_size,
+        items
+            .into_iter()
+            .map(|item| SizedWrapper::new(key_func.clone(), item)),
+        1,
+    )
+    .into_iter()
+    .map(|bin| bin.map(|item| item.take()))
+    .collect()
 }
 
 #[doc(hidden)]
@@ -64,6 +94,36 @@ mod tests {
                 vec![19],               // 19
             ],
         );
+
+        assert_eq!(expected, result)
+    }
+
+    #[test]
+    fn it_works_by_key() {
+        let (test_data, bin_size) = generate_test_set_a();
+
+        let test_data = test_data
+            .into_iter()
+            .map(|item| item.make_unpacked())
+            .collect::<Vec<_>>();
+
+        let result = first_fit_by_key(bin_size, test_data, |item| item.size);
+
+        // First fit does not give an optimal solution
+
+        let expected: Vec<_> = generate_test_bins(
+            20,
+            vec![
+                vec![1, 1, 1, 1, 3, 4], // 11
+                vec![10, 10],           // 20
+                vec![10],               // 10
+                vec![19],               // 19
+                vec![19],               // 19
+            ],
+        )
+        .into_iter()
+        .map(|bin| bin.map(|item| item.make_unpacked()))
+        .collect();
 
         assert_eq!(expected, result)
     }

--- a/src/wrapper/mod.rs
+++ b/src/wrapper/mod.rs
@@ -1,0 +1,113 @@
+use std::ops::{Deref, DerefMut};
+
+/// This struct wraps an item with a function that returns the size of the item.
+///
+/// This is an alternative to implementing the [`crate::Pack`] trait on the type:
+/// instead, you can transform your collection into a collection of [`SizedWrapper`]s
+/// before passing it to one of the packing functions,
+/// or else use the `by_key` versions of the packing functions
+/// (which are implemented using this wrapper).
+pub struct SizedWrapper<SizeFunc, T>
+where
+    SizeFunc: Fn(&T) -> usize,
+{
+    pub key_func: SizeFunc,
+    pub item: T,
+}
+
+impl<SizeFunc, T> SizedWrapper<SizeFunc, T>
+where
+    SizeFunc: Fn(&T) -> usize,
+{
+    pub fn new(key_func: SizeFunc, item: T) -> Self {
+        Self { key_func, item }
+    }
+
+    pub fn take(self) -> T {
+        self.item
+    }
+}
+
+impl<SizeFunc, T> crate::Pack for SizedWrapper<SizeFunc, T>
+where
+    SizeFunc: Fn(&T) -> usize,
+{
+    fn size(&self) -> usize {
+        (self.key_func)(&self.item)
+    }
+}
+
+impl<F, T> Deref for SizedWrapper<F, T>
+where
+    F: Fn(&T) -> usize,
+{
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.item
+    }
+}
+
+impl<F, T> DerefMut for SizedWrapper<F, T>
+where
+    F: Fn(&T) -> usize,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.item
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ensure that the wrapper struct does not introduce any memory overhead
+    /// when the key function is a simple function pointer
+    /// or a non-capturing closure.
+    #[test]
+    fn check_size_eq() {
+        let original = vec![1, 2, 3];
+        let wrapper = SizedWrapper::new(Vec::len, original.clone());
+
+        assert_eq!(
+            std::mem::size_of_val(&original),
+            std::mem::size_of_val(&wrapper)
+        );
+
+        let wrapper_weird = SizedWrapper::new(|_| 1, original.clone());
+
+        assert_eq!(
+            std::mem::size_of_val(&original),
+            std::mem::size_of_val(&wrapper_weird)
+        );
+    }
+
+    /// Ensure that when the key function captures some data,
+    /// that the wrapper struct's size is a simple combination of the size of the captured data
+    /// and whatever it's wrapping.
+    #[test]
+    fn check_size_when_combining() {
+        let original = vec![1, 2, 3];
+        let (sender, _recv) = std::sync::mpsc::channel();
+        let sender_size = std::mem::size_of_val(&sender);
+
+        let key_function = move |item: &Vec<i32>| {
+            // naughty: we're sending a copy of the vector into the channel
+            sender.send(item.to_vec().clone()).unwrap();
+            item.iter().map(|v| *v as usize).sum()
+        };
+
+        let wrapper = SizedWrapper::new(key_function, original.clone());
+
+        // The sender has some size...
+        assert_ne!(sender_size, 0);
+
+        // and the wrapper's size is equal to the size of the sender, and the size of the `original` Vec.
+        // This is because the wrapper does not actually contain the function pointer,
+        // it only contains `sender` and `original`;
+        // the function pointer is associated with it implicitly by the type system.
+        assert_eq!(
+            std::mem::size_of_val(&original) + sender_size,
+            std::mem::size_of_val(&wrapper)
+        );
+    }
+}


### PR DESCRIPTION
It's sometimes not convenient to implement `Pack` for whatever type you're trying to bin-pack.
In the standard library for `Vec<T>`, you can use [`sort()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.sort) if your type implements `Ord`, and [`sort_by_key(fn)`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.sort_by_key) if not.

Instead of using a custom wrapper that implements `Pack`, you can instead use one of the new `by_key` methods and pass in a closure that you would have used.

A custom wrapper is in fact provided, it's called `SizedWrapper`. It holds a function to transform the inner item into a size, like the `Pack` trait does. There's also a test included that proves that the wrapper has zero overhead for the most common case. 