### PR TITLE
Add Next-K-Fit algorithm

### DIFF
--- a/src/online/mod.rs
+++ b/src/online/mod.rs
@@ -1,1 +1,4 @@
 pub mod first_fit;
+pub mod next_k_fit;
+pub mod online_packer;
+pub use online_packer::OnlinePacker;

--- a/src/online/next_k_fit.rs
+++ b/src/online/next_k_fit.rs
@@ -1,0 +1,169 @@
+use std::usize;
+
+use crate::{Bin, Pack};
+
+use super::OnlinePacker;
+
+/// This implements the [Next-K-fit](https://en.wikipedia.org/wiki/Next-fit_bin_packing)
+/// bin packing algorithm.
+///
+/// A total of `K` bins are kept open.
+/// When a new item arrives, we attempt to put it into any one of the open bins.
+/// If none of the open bins are big enough, the most-filled bin is closed,
+/// and a new bin is opened to hold the new item.
+#[derive(Debug)]
+pub struct NextKFitPacker<Item, SizeFn> {
+    bins: Vec<Bin<Item>>,
+    max_bin_size: usize,
+    size_fn: SizeFn,
+}
+
+impl<Item, SizeFn> NextKFitPacker<Item, SizeFn> {
+    /// Create a new NextKFitPacker.
+    ///
+    /// It will keep open `k` bins,
+    /// each of which will fit a maximum of `size`.
+    ///
+    /// The size of a single element is determined by the `size_fn`.
+    ///
+    /// Panics if `k` or `size` is 0.
+    pub fn new_with_key(k: usize, size: usize, size_fn: SizeFn) -> Self {
+        assert_ne!(k, 0, "k must be greater than 0");
+        assert_ne!(size, 0, "size must be greater than 0");
+
+        Self {
+            bins: (0..k).map(|_| Bin::with_capacity(size)).collect::<Vec<_>>(),
+            max_bin_size: size,
+            size_fn,
+        }
+    }
+}
+
+impl<Item> NextKFitPacker<Item, fn(&Item) -> usize> {
+    /// Create a new NextKFitPacker.
+    ///
+    /// This function requires that `Item` implements [`Pack`].
+    /// If your type doesn't, consider using [`new_with_key`](NextKFitPacker::new_with_key).
+    pub fn new(k: usize, size: usize) -> NextKFitPacker<Item, fn(&Item) -> usize>
+    where
+        Item: Pack,
+    {
+        fn pack_size(item: &impl Pack) -> usize {
+            item.size()
+        }
+
+        NextKFitPacker::<Item, _>::new_with_key(k, size, pack_size)
+    }
+}
+
+impl<Item, SizeFn> OnlinePacker<Item> for NextKFitPacker<Item, SizeFn>
+where
+    SizeFn: Fn(&Item) -> usize,
+{
+    fn try_add(
+        &mut self,
+        item: Item,
+    ) -> Result<Vec<Bin<Item>>, super::online_packer::OnlinePackerError<Item>> {
+        let item_size = (self.size_fn)(&item);
+        if item_size > self.max_bin_size {
+            return Err(super::online_packer::OnlinePackerError::ItemTooLarge(item));
+        }
+
+        // See if the item fits in any of the open bins.
+        // At the same time, keep track of the most-filled bin.
+        let mut most_filled_bin_idx = 0;
+        let mut most_filled_bin_capacity = usize::MAX;
+        for (bin_idx, bin) in self.bins.iter_mut().enumerate() {
+            if bin.remaining_capacity < most_filled_bin_capacity {
+                most_filled_bin_idx = bin_idx;
+                most_filled_bin_capacity = bin.remaining_capacity;
+            }
+
+            if item_size <= bin.remaining_capacity {
+                bin.add_with_size(item, item_size);
+                return Ok(Vec::new());
+            }
+        }
+
+        // The item didn't fit into any of the bins,
+        // so we need to:
+        // - open a new bin
+        // - put the new item in it
+        // - close the most-filled bin (and return it)
+        let mut bin = Bin::with_item_and_size(self.max_bin_size, item, item_size);
+
+        std::mem::swap(&mut self.bins[most_filled_bin_idx], &mut bin);
+
+        Ok(vec![bin])
+    }
+
+    fn finalize(mut self) -> Vec<Bin<Item>> {
+        // TODO: maybe the remaining bins could be packed more efficiently?
+        // Right now, we just return all the bins we have that aren't empty.
+        self.bins.retain(|bin| !bin.contents.is_empty());
+        self.bins
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{generate_test_bins, generate_test_set_a, MyItem};
+
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_no_bins() {
+        let packer: NextKFitPacker<MyItem, _> = NextKFitPacker::new(3, 10);
+        assert_eq!(packer.finalize(), vec![]);
+
+        let packer: NextKFitPacker<MyItem, _> = NextKFitPacker::new(3, 10);
+        assert_eq!(packer.pack_all(vec![].into_iter()).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn test_dataset_a_k1() {
+        let (test_data, bin_size) = generate_test_set_a();
+        let packer = NextKFitPacker::new(1, bin_size);
+
+        let bins = packer.pack_all(test_data.into_iter()).unwrap();
+
+        // With one bin lookahead, NextKFit does not give an optimal solution
+        let expected = generate_test_bins(
+            20,
+            vec![
+                vec![1, 1, 1, 1, 3, 4], // 11
+                vec![10, 10],           // 20
+                vec![10],               // 10
+                vec![19],               // 19
+                vec![19],               // 19
+            ],
+        );
+
+        assert_eq!(expected, bins);
+    }
+    #[test]
+    fn test_dataset_a_k2() {
+        let (test_data, bin_size) = generate_test_set_a();
+        let packer = NextKFitPacker::new(2, bin_size);
+
+        let mut bins = packer.pack_all(test_data.into_iter()).unwrap();
+
+        // With two bin lookahead, NextKFit does not give an optimal solution;
+        // however, it emits the same solution as Next1Fit, above,
+        // but in a different order.
+        let expected = generate_test_bins(
+            20,
+            vec![
+                vec![10, 10],           // 20
+                vec![1, 1, 1, 1, 3, 4], // 11
+                vec![19],               // 19
+                vec![19],               // 19
+                vec![10],               // 10
+            ],
+        );
+
+        println!("{:#?}", bins);
+
+        assert_eq!(expected, bins);
+    }
+}

--- a/src/online/online_packer.rs
+++ b/src/online/online_packer.rs
@@ -1,0 +1,70 @@
+use crate::Bin;
+
+/// This trait is implemented by online packers.
+/// These algorithms consume items one by one,
+/// and at each step they decide whether to close any bins
+/// (giving them away for later use) or not.
+pub trait OnlinePacker<Item> {
+    /// Try adding a new item to the packer.
+    ///
+    /// If this results in any bins getting closed, they will be returned in the `Ok(Vec)`;
+    /// if no bins can be closed yet, the Vec will be empty.
+    fn try_add(&mut self, item: Item) -> Result<Vec<Bin<Item>>, OnlinePackerError<Item>>;
+
+    /// Add a new item to the packer.
+    ///
+    /// Like [`OnlinePacker::try_add`], but will panic if the item cannot be added.
+    fn add(&mut self, item: Item) -> Vec<Bin<Item>> {
+        match self.try_add(item) {
+            Ok(bins) => bins,
+            Err(_) => panic!("Could not add item to packer"),
+        }
+    }
+
+    /// No new items will be coming in.
+    /// If there were any bins still open,
+    /// this will close and return them.
+    fn finalize(self) -> Vec<Bin<Item>>;
+
+    /// Helper function to process an entire sequence of items
+    /// and return the bins in one go.
+    ///
+    /// It runs [`add`](OnlinePacker::add) on each item,
+    /// and then calls [`finalize`](OnlinePacker::finalize),
+    /// collecting the bins in the process.
+    ///
+    /// Note that there might have been some items in the packer before this function is called:
+    /// these will be included in the final result, along with any that came in from the `items` parameter.
+    ///
+    /// If an [`OnlinePackerError`] occurs in the middle of the process,
+    /// this will stop iterating over the items,
+    /// and return all the state we have so far.
+    fn pack_all<Iterable>(
+        self,
+        mut items: Iterable,
+    ) -> Result<Vec<Bin<Item>>, (OnlinePackerError<Item>, Self, Iterable, Vec<Bin<Item>>)>
+    where
+        Self: Sized,
+        Iterable: Iterator<Item = Item>,
+    {
+        let mut closed_bins = Vec::new();
+        let mut packer = self;
+        while let Some(item) = items.next() {
+            match packer.try_add(item) {
+                Ok(closed) => closed_bins.extend(closed),
+                Err(err) => return Err((err, packer, items, closed_bins)),
+            }
+        }
+
+        closed_bins.extend(packer.finalize());
+        Ok(closed_bins)
+    }
+}
+
+/// Error returned when an item cannot be added to an online packer.
+#[derive(Debug)]
+pub enum OnlinePackerError<T> {
+    /// The item is too big to fit into any bin that this packer can make:
+    /// for example, the bins are size 10 and you're trying to pack an item of size 50.
+    ItemTooLarge(T),
+}


### PR DESCRIPTION
This adds the [Next-K-fit](https://en.wikipedia.org/wiki/Next-fit_bin_packing) algorithm.

Previously you had the `first_fit` algorithm, which is "online" only in the sense that you didn't need to have the entire Vec of items on hand to start it. You still had to wait for all the items to come in to get any output. This is a big downside of this approach, and has issues when you would like to sort items that you can't actually hold all at once (for example, if they're too big to fit into memory all together). 

In order to have it work truly online, I also add the `OnlinePacker` trait.
This is a structure that takes input items in order, and puts them in an internal storage.
When ready, it produces a `Bin` of the items it has, and gives it back to you.
This way, it can be used with items that are being generated on the fly,
and you'll still get some output back in the middle of the process.

For anyone who needs the old behavior, there's a simple driver called `pack_all(impl Iterator<Item=T>)` that will give you a `Vec<Bin<T>>`, like your `first_fit` function did. You can have more complicated drivers if you need them, wrapping the core trait in a sans-IO style (ref: https://fasterthanli.me/articles/the-case-for-sans-io, https://youtu.be/RYHYiXMJdZI).

