### PR TITLE
Applying clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,38 +6,41 @@
 //! use pack_it_up::Pack;
 //! use pack_it_up::offline::first_fit_decreasing::first_fit_decreasing;
 //!
+//! /// This is the struct you want to pack into bins.
+//! /// In this example, it only has two fields:
+//! /// some content and the item's size.
 //! #[derive(Debug, Eq, PartialEq)]
 //! struct MyItem {
 //!     some_content: i32,
 //!     size: usize,
 //! }
 //!
+//! /// This trait tells the algorithms how big the item is
 //! impl Pack for MyItem {
 //!     fn size(&self) -> usize {
 //!         self.size
 //!     }
 //! }
 //!
-//! fn main() {
-//!     let my_items = vec![
-//!         MyItem { some_content: 1, size: 1, },
-//!         MyItem { some_content: 2, size: 2, },
-//!         MyItem { some_content: 3, size: 19, },
-//!         MyItem { some_content: 4, size: 17, },
-//!         MyItem { some_content: 5, size: 1, },
-//!     ];
+//! let my_items = vec![
+//!     MyItem { some_content: 1, size: 1, },
+//!     MyItem { some_content: 2, size: 2, },
+//!     MyItem { some_content: 3, size: 19, },
+//!     MyItem { some_content: 4, size: 17, },
+//!     MyItem { some_content: 5, size: 1, },
+//! ];
 //!
-//!     let mut bins = first_fit_decreasing(20, my_items);
+//! // Packing the items into bins where the total size of each bin is at most 20
+//! let mut bins = first_fit_decreasing(20, my_items);
 //!
-//!     // The above will result in 2 full bins
-//!     assert_eq!(2, bins.len());
+//! // The above will result in 2 full bins
+//! assert_eq!(2, bins.len());
 //!
-//!     let first_bin_contents = bins.remove(0).into_contents();
-//!     assert_eq!(vec![MyItem{ some_content: 3, size: 19 }, MyItem { some_content: 1, size: 1 }], first_bin_contents);
+//! let first_bin_contents = bins.remove(0).into_contents();
+//! assert_eq!(vec![MyItem{ some_content: 3, size: 19 }, MyItem { some_content: 1, size: 1 }], first_bin_contents);
 //!
-//!     let second_bin_contents = bins.remove(0).into_contents();
-//!     assert_eq!(vec![MyItem{ some_content: 4, size: 17 }, MyItem { some_content: 2, size: 2 }, MyItem { some_content: 5, size: 1 }], second_bin_contents);
-//! }
+//! let second_bin_contents = bins.remove(0).into_contents();
+//! assert_eq!(vec![MyItem{ some_content: 4, size: 17 }, MyItem { some_content: 2, size: 2 }, MyItem { some_content: 5, size: 1 }], second_bin_contents);
 //! ```
 
 pub mod offline;

--- a/src/offline/first_fit_decreasing.rs
+++ b/src/offline/first_fit_decreasing.rs
@@ -11,7 +11,12 @@ where
     assert!(bin_size > 0, "Bin size must be greater than 0");
 
     // Sort the items in decreasing order
-    items.sort_unstable_by_key(Pack::size);
+    // TODO: the following line could have been possibly replaced by
+    //   items.sort_unstable_by_key(Pack::size);
+    // but doing that somehow breaks the ordering
+    // that this function requires to give the correct answer?!?!
+    #[allow(clippy::unnecessary_sort_by)]
+    items.sort_unstable_by(|a, b| b.size().cmp(&a.size()));
 
     let lower_bound: usize = ((items.iter().map(|item| item.size()).sum::<usize>() as f64)
         / (bin_size as f64))
@@ -39,13 +44,21 @@ where
 {
     assert!(bin_size > 0, "Bin size must be greater than 0");
 
-    // Sort the items in decreasing order
+    // Wrap items in a SizedWrapper with the key function
+    // This should be a low-to-no-impact operation if the key function is Copy
+    // (because SizedWrapper is a zero-overhead struct in that case)
     let mut items: Vec<_> = items
         .into_iter()
         .map(|item| SizedWrapper::new(key_func.clone(), item))
         .collect();
 
-    items.sort_unstable_by_key(Pack::size);
+    // Sort the items in decreasing order
+    // TODO: the following line could have been possibly replaced by
+    //   items.sort_unstable_by_key(Pack::size);
+    // but doing that somehow breaks the ordering
+    // that this function requires to give the correct answer?!?!
+    #[allow(clippy::unnecessary_sort_by)]
+    items.sort_unstable_by(|a, b| b.size().cmp(&a.size()));
 
     let lower_bound: usize = ((items.iter().map(|item| item.size()).sum::<usize>() as f64)
         / (bin_size as f64))

--- a/src/offline/first_fit_decreasing.rs
+++ b/src/offline/first_fit_decreasing.rs
@@ -11,7 +11,7 @@ where
     assert!(bin_size > 0, "Bin size must be greater than 0");
 
     // Sort the items in decreasing order
-    items.sort_unstable_by(|a, b| b.size().cmp(&a.size()));
+    items.sort_unstable_by_key(Pack::size);
 
     let lower_bound: usize = ((items.iter().map(|item| item.size()).sum::<usize>() as f64)
         / (bin_size as f64))
@@ -29,7 +29,6 @@ where
 ///
 /// This function will be cloned for each item
 /// (but if it's a simple function pointer or a non-capturing closure, then it is a no-op).
-
 pub fn first_fit_decreasing_by_key<T, SizeFunc>(
     bin_size: usize,
     items: Vec<T>,
@@ -46,7 +45,7 @@ where
         .map(|item| SizedWrapper::new(key_func.clone(), item))
         .collect();
 
-    items.sort_unstable_by(|a, b| b.size().cmp(&a.size()));
+    items.sort_unstable_by_key(Pack::size);
 
     let lower_bound: usize = ((items.iter().map(|item| item.size()).sum::<usize>() as f64)
         / (bin_size as f64))

--- a/src/online/first_fit.rs
+++ b/src/online/first_fit.rs
@@ -58,8 +58,7 @@ where
         // Find the first bin that the item fits in
         match bins
             .iter_mut()
-            .filter(|bin| item.size() <= bin.remaining_capacity)
-            .next()
+            .find(|bin| item.size() <= bin.remaining_capacity)
         {
             Some(bin) => bin.add(item),
             None => bins.push(Bin::with_item(bin_size, item)),

--- a/src/online/next_k_fit.rs
+++ b/src/online/next_k_fit.rs
@@ -1,5 +1,3 @@
-use std::usize;
-
 use crate::{Bin, Pack};
 
 use super::OnlinePacker;


### PR DESCRIPTION
Lints fixed: 

- in doctests, the `main` function is not needed, so I've removed it (and instead added some comments on the struct declarations).
- `iterator.find(op).next()` == `iterator.find(op)`
- (breaking change, but this feature was added just now, so it doesn't matter) Clippy doesn't like the old return type from `OnlinePacker::pack_all`, so I've refactored the error case into a separate struct.

---

There's another lint remaining in `first_fit_decreasing{,_by_key}`: normally, `vec.sort_by(|a, b| key_fn(a).cmp(&key_fn(b)))` could be replaced with `vec.sort_by_key(key_fn)`. I tried doing that, but it changed the ordering that the items are returned in.

I tried adding a feature to sort the results into a canonical ordering, so that different return orders don't change the test output. However, I realized that this actually _changes the correctness of the result_: with the other sort function, it gives you 5 bins, where it's supposed to give 4. This is some advanced wtfery which I can't quite work out, but I think it might be indicating a problem with the algorithm itself. 